### PR TITLE
Hide service credentials from API responses

### DIFF
--- a/frontend/src/pages/initial-configuration/components/ServiceCard.jsx
+++ b/frontend/src/pages/initial-configuration/components/ServiceCard.jsx
@@ -8,10 +8,12 @@ const ServiceCard = ({ service, onTest, onConfigChange, testStatus }) => {
   const [showPassword, setShowPassword] = useState(false);
   const [config, setConfig] = useState({
     url: service?.url || "",
-    apiKey: service?.apiKey || "",
+    apiKey: "", // Never pre-filled — API never returns the actual key
     username: service?.username || "",
-    password: service?.password || "",
+    password: "", // Never pre-filled — API never returns the actual password
     port: service?.port || "",
+    hasApiKey: service?.hasApiKey || false,
+    hasPassword: service?.hasPassword || false,
   });
 
   const isQBittorrent = service?.id === "qbittorrent";
@@ -20,12 +22,14 @@ const ServiceCard = ({ service, onTest, onConfigChange, testStatus }) => {
   useEffect(() => {
     setConfig({
       url: service?.url || "",
-      apiKey: service?.apiKey || "",
+      apiKey: "",
       username: service?.username || "",
-      password: service?.password || "",
+      password: "",
       port: service?.port || "",
+      hasApiKey: service?.hasApiKey || false,
+      hasPassword: service?.hasPassword || false,
     });
-  }, [service?.url, service?.apiKey, service?.username, service?.password, service?.port]);
+  }, [service?.url, service?.username, service?.port, service?.hasApiKey, service?.hasPassword]);
 
   const handleInputChange = (field, value) => {
     const updatedConfig = { ...config, [field]: value };
@@ -62,8 +66,8 @@ const ServiceCard = ({ service, onTest, onConfigChange, testStatus }) => {
   };
 
   const isConfigValid = isQBittorrent
-    ? config?.url && config?.username
-    : config?.url && config?.apiKey;
+    ? config?.url && config?.username && (config?.password || config?.hasPassword)
+    : config?.url && (config?.apiKey || config?.hasApiKey);
 
   return (
     <div className="bg-card border border-border rounded-lg p-4 md:p-6 shadow-elevation-2 transition-smooth hover:shadow-elevation-3">
@@ -123,10 +127,12 @@ const ServiceCard = ({ service, onTest, onConfigChange, testStatus }) => {
               <Input
                 label="Password"
                 type={showPassword ? "text" : "password"}
-                placeholder="Enter your password"
+                placeholder={
+                  config?.hasPassword ? "Saved — enter new value to change" : "Enter your password"
+                }
                 value={config?.password}
                 onChange={(e) => handleInputChange("password", e?.target?.value)}
-                required
+                required={!config?.hasPassword}
                 description="qBittorrent Web UI password"
               />
               <button
@@ -144,10 +150,12 @@ const ServiceCard = ({ service, onTest, onConfigChange, testStatus }) => {
             <Input
               label="API Key"
               type={showApiKey ? "text" : "password"}
-              placeholder="Enter your API key"
+              placeholder={
+                config?.hasApiKey ? "Saved — enter new value to change" : "Enter your API key"
+              }
               value={config?.apiKey}
               onChange={(e) => handleInputChange("apiKey", e?.target?.value)}
-              required
+              required={!config?.hasApiKey}
               description="Found in service settings under API section"
             />
             <button
@@ -199,7 +207,7 @@ const ServiceCard = ({ service, onTest, onConfigChange, testStatus }) => {
           Test Connection
         </Button>
       </div>
-      {(config?.apiKey || config?.password) && (
+      {(config?.apiKey || config?.hasApiKey || config?.password || config?.hasPassword) && (
         <div className="mt-4 flex items-center gap-2 text-xs text-muted-foreground">
           <Icon name="Shield" size={14} />
           <span>{isQBittorrent ? "Credentials" : "API key"} will be encrypted before storage</span>

--- a/frontend/src/pages/initial-configuration/index.jsx
+++ b/frontend/src/pages/initial-configuration/index.jsx
@@ -99,10 +99,12 @@ const InitialConfiguration = () => {
           savedConfigs?.forEach((config) => {
             configMap[config.serviceName] = {
               url: config?.url,
-              apiKey: config?.apiKey,
-              username: config?.username,
-              password: config?.password,
+              apiKey: "", // Not returned by API — never pre-fill
+              username: config?.username || "",
+              password: "", // Not returned by API — never pre-fill
               port: config?.port?.toString() || "",
+              hasApiKey: config?.hasApiKey || false,
+              hasPassword: config?.hasPassword || false,
             };
 
             if (config?.testStatus) {
@@ -144,7 +146,9 @@ const InitialConfiguration = () => {
     }));
 
     const isQBittorrent = serviceId === "qbittorrent";
-    const isValid = isQBittorrent ? config?.url && config?.username : config?.url && config?.apiKey;
+    const isValid = isQBittorrent
+      ? config?.url && config?.username && (config?.password || config?.hasPassword)
+      : config?.url && (config?.apiKey || config?.hasApiKey);
 
     const hasValidUrl = config?.url?.startsWith("http://") || config?.url?.startsWith("https://");
 
@@ -330,6 +334,8 @@ const InitialConfiguration = () => {
                   username: configurations?.[service?.id]?.username || "",
                   password: configurations?.[service?.id]?.password || "",
                   port: configurations?.[service?.id]?.port || service?.port,
+                  hasApiKey: configurations?.[service?.id]?.hasApiKey || false,
+                  hasPassword: configurations?.[service?.id]?.hasPassword || false,
                 }}
                 onTest={handleTestConnection}
                 onConfigChange={handleConfigChange}


### PR DESCRIPTION
## Summary

- `GET /api/services/` and `GET /api/services/{name}` no longer return `api_key` or `password`
- New `has_api_key: bool` and `has_password: bool` flags tell the UI whether a secret is stored
- `PUT /api/services/{name}`: omitting or sending `null`/`""` for a credential field preserves the stored value — only a non-empty new value replaces it
- Frontend form shows `"Saved — enter new value to change"` placeholder when a credential is already set, and skips the field in the save payload unless the user typed something new

## Changes

| Layer | File | What changed |
|-------|------|-------------|
| Backend | `app/api/schemas.py` | `ServiceConfigurationResponse` excludes secrets, adds `has_api_key`/`has_password` |
| Backend | `app/api/routes/services.py` | PUT skips credential fields when value is null/empty |
| Backend | `tests/test_services_routes.py` | +5 tests: no secrets in response, preserve/replace credential behavior |
| Frontend | `src/services/configService.js` | `mapServiceResponse` maps flags; `saveServiceConfiguration` omits credentials when empty |
| Frontend | `src/pages/initial-configuration/components/ServiceCard.jsx` | Placeholder + `required` logic updated; `isConfigValid` uses `hasApiKey`/`hasPassword` |
| Frontend | `src/pages/initial-configuration/index.jsx` | Passes flags through config state; validation accounts for saved credentials |

## Test plan

- [ ] `cd backend && pytest` → 79 passed
- [ ] `cd frontend && npm test` → 51 passed
- [ ] `GET /api/services/sonarr` on a configured service → no `api_key` field in response, `has_api_key: true`
- [ ] Edit a service URL without touching the API key field → key unchanged in DB
- [ ] Enter a new API key and save → key updated in DB
- [ ] Service card shows `"Saved — enter new value to change"` placeholder when credential exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)