### PR TITLE
Add backend tests and remove unused API endpoints

### DIFF
--- a/backend/app/api/routes/torrents.py
+++ b/backend/app/api/routes/torrents.py
@@ -12,7 +12,6 @@ from sqlalchemy.orm import Session
 from app.db import get_db
 from app.models.models import LibraryItemTorrent, ServiceConfiguration
 from app.services.connector_factory import create_connector
-from app.services.torrent_enrichment_service import TorrentEnrichmentService
 
 logger = logging.getLogger(__name__)
 
@@ -132,35 +131,3 @@ async def get_item_torrents(library_item_id: str, db: Session = Depends(get_db))
         }
         for row in rows
     ]
-
-
-@router.post("/enrich")
-async def enrich_library_items(limit: int | None = None, db: Session = Depends(get_db)) -> dict[str, Any]:
-    """
-    Enrichit les library_items avec les données qBittorrent
-
-    Args:
-        limit: Nombre maximum d'items à traiter (optionnel)
-
-    Returns:
-        Statistiques de l'enrichissement
-    """
-    service = TorrentEnrichmentService(db)
-    stats = await service.enrich_all_items(limit=limit)
-    return stats
-
-
-@router.post("/enrich/recent")
-async def enrich_recent_items(days: int = 7, db: Session = Depends(get_db)) -> dict[str, Any]:
-    """
-    Enrichit les items récents avec les données qBittorrent
-
-    Args:
-        days: Nombre de jours en arrière (défaut: 7)
-
-    Returns:
-        Statistiques de l'enrichissement
-    """
-    service = TorrentEnrichmentService(db)
-    stats = await service.enrich_recent_items(days=days)
-    return stats

--- a/backend/tests/test_prowlarr_connector.py
+++ b/backend/tests/test_prowlarr_connector.py
@@ -1,0 +1,346 @@
+"""
+Unit tests for ProwlarrConnector.
+
+Covers:
+- test_connection: success and failure
+- get_indexers: returns list, handles exception
+- get_indexer_stats: returns stats, handles exception
+- get_indexers_with_stats: merges correctly, falls back to empty stats
+- toggle_indexer: success and failure
+- get_history: field mapping, indexer name lookup, categories parsing
+- search: result mapping, exception handling
+- grab: success and failure
+"""
+
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "3306")
+os.environ.setdefault("DB_USER", "test")
+os.environ.setdefault("DB_PASSWORD", "test")
+os.environ.setdefault("DB_NAME", "test")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-pilotarr-testing-only!")
+os.environ.setdefault("API_KEY", "test-api-key")
+os.environ.setdefault("WEBHOOK_SECRET", "test-webhook-secret")
+
+from app.services.prowlarr_connector import ProwlarrConnector  # noqa: E402
+
+
+def _make_response(data, status_code=200):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = data
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+@pytest.fixture()
+def connector():
+    return ProwlarrConnector(base_url="http://prowlarr", api_key="test-key", port=9696)
+
+
+# ── Init ──────────────────────────────────────────────────────────────────────
+
+
+class TestInit:
+    def test_port_appended_to_base_url(self):
+        c = ProwlarrConnector(base_url="http://prowlarr", api_key="key", port=9696)
+        assert c.base_url == "http://prowlarr:9696"
+
+    def test_port_not_duplicated_when_already_in_url(self):
+        c = ProwlarrConnector(base_url="http://prowlarr:9696", api_key="key", port=9696)
+        assert c.base_url == "http://prowlarr:9696"
+
+    def test_api_key_in_headers(self, connector):
+        headers = connector._get_headers()
+        assert headers["X-Api-Key"] == "test-key"
+        assert headers["Content-Type"] == "application/json"
+
+
+# ── test_connection ───────────────────────────────────────────────────────────
+
+
+class TestTestConnection:
+    async def test_success_returns_true_with_version(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response({"version": "1.2.3"}))
+        ok, msg = await connector.test_connection()
+        assert ok is True
+        assert "1.2.3" in msg
+
+    async def test_failure_returns_false(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        ok, msg = await connector.test_connection()
+        assert ok is False
+        assert "Connection error" in msg
+
+
+# ── get_indexers ──────────────────────────────────────────────────────────────
+
+
+class TestGetIndexers:
+    async def test_returns_list(self, connector):
+        payload = [{"id": 1, "name": "NZBgeek"}, {"id": 2, "name": "TPB"}]
+        connector.client.get = AsyncMock(return_value=_make_response(payload))
+        result = await connector.get_indexers()
+        assert len(result) == 2
+        assert result[0]["name"] == "NZBgeek"
+
+    async def test_exception_returns_empty_list(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.get_indexers()
+        assert result == []
+
+
+# ── get_indexer_stats ─────────────────────────────────────────────────────────
+
+
+class TestGetIndexerStats:
+    async def test_returns_indexers_list(self, connector):
+        payload = {"indexers": [{"indexerId": 1, "numberOfQueries": 42}]}
+        connector.client.get = AsyncMock(return_value=_make_response(payload))
+        result = await connector.get_indexer_stats()
+        assert len(result) == 1
+        assert result[0]["numberOfQueries"] == 42
+
+    async def test_missing_key_returns_empty(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response({}))
+        result = await connector.get_indexer_stats()
+        assert result == []
+
+    async def test_exception_returns_empty(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.get_indexer_stats()
+        assert result == []
+
+
+# ── get_indexers_with_stats ───────────────────────────────────────────────────
+
+
+_INDEXER = {
+    "id": 1,
+    "name": "NZBgeek",
+    "enable": True,
+    "protocol": "usenet",
+    "privacy": "private",
+    "capabilities": {"categories": [{"name": "Movies"}, {"name": "TV"}]},
+}
+_STATS = {
+    "indexerId": 1,
+    "numberOfQueries": 100,
+    "numberOfFailedQueries": 5,
+    "numberOfGrabs": 20,
+    "numberOfFailedGrabs": 1,
+    "averageResponseTime": 350,
+}
+
+
+class TestGetIndexersWithStats:
+    async def test_merges_stats_by_indexer_id(self, connector):
+        connector.get_indexers = AsyncMock(return_value=[_INDEXER])
+        connector.get_indexer_stats = AsyncMock(return_value=[_STATS])
+        result = await connector.get_indexers_with_stats()
+        assert len(result) == 1
+        item = result[0]
+        assert item["id"] == 1
+        assert item["name"] == "NZBgeek"
+        assert item["stats"]["numberOfQueries"] == 100
+        assert item["stats"]["averageResponseTime"] == 350
+        assert item["capabilities"]["categories"] == ["Movies", "TV"]
+
+    async def test_falls_back_to_zero_stats_when_no_match(self, connector):
+        connector.get_indexers = AsyncMock(return_value=[_INDEXER])
+        connector.get_indexer_stats = AsyncMock(return_value=[])
+        result = await connector.get_indexers_with_stats()
+        stats = result[0]["stats"]
+        assert stats["numberOfQueries"] == 0
+        assert stats["numberOfGrabs"] == 0
+        assert stats["averageResponseTime"] == 0
+
+    async def test_empty_indexers_returns_empty_list(self, connector):
+        connector.get_indexers = AsyncMock(return_value=[])
+        connector.get_indexer_stats = AsyncMock(return_value=[])
+        result = await connector.get_indexers_with_stats()
+        assert result == []
+
+    async def test_multiple_indexers_mapped_independently(self, connector):
+        indexers = [
+            {**_INDEXER, "id": 1, "name": "A"},
+            {**_INDEXER, "id": 2, "name": "B"},
+        ]
+        stats = [
+            {**_STATS, "indexerId": 1, "numberOfQueries": 10},
+            {**_STATS, "indexerId": 2, "numberOfQueries": 20},
+        ]
+        connector.get_indexers = AsyncMock(return_value=indexers)
+        connector.get_indexer_stats = AsyncMock(return_value=stats)
+        result = await connector.get_indexers_with_stats()
+        assert result[0]["stats"]["numberOfQueries"] == 10
+        assert result[1]["stats"]["numberOfQueries"] == 20
+
+
+# ── toggle_indexer ────────────────────────────────────────────────────────────
+
+
+class TestToggleIndexer:
+    async def test_success_returns_true(self, connector):
+        existing = {"id": 1, "name": "TPB", "enable": False}
+        connector.client.get = AsyncMock(return_value=_make_response(existing))
+        connector.client.put = AsyncMock(return_value=_make_response({"id": 1, "enable": True}))
+        result = await connector.toggle_indexer(1, enable=True)
+        assert result is True
+
+    async def test_puts_correct_enable_value(self, connector):
+        existing = {"id": 1, "enable": True}
+        connector.client.get = AsyncMock(return_value=_make_response(existing))
+        connector.client.put = AsyncMock(return_value=_make_response(existing))
+        await connector.toggle_indexer(1, enable=False)
+        payload = connector.client.put.call_args.kwargs["json"]
+        assert payload["enable"] is False
+
+    async def test_http_error_returns_false(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.toggle_indexer(99, enable=True)
+        assert result is False
+
+
+# ── get_history ───────────────────────────────────────────────────────────────
+
+
+_RAW_RECORD = {
+    "id": 10,
+    "date": "2024-01-15T10:00:00Z",
+    "indexerId": 1,
+    "eventType": "grabRelease",
+    "successful": True,
+    "data": {
+        "query": "Breaking Bad",
+        "categories": "5000, 5030",
+        "source": "Sonarr",
+    },
+}
+_INDEXERS = [{"id": 1, "name": "NZBgeek"}]
+
+
+class TestGetHistory:
+    async def test_returns_mapped_history_item(self, connector):
+        connector.get_indexers = AsyncMock(return_value=_INDEXERS)
+        connector.client.get = AsyncMock(return_value=_make_response({"records": [_RAW_RECORD]}))
+        result = await connector.get_history(page_size=5)
+        assert len(result) == 1
+        item = result[0]
+        assert item["id"] == 10
+        assert item["date"] == "2024-01-15T10:00:00Z"
+        assert item["indexer"] == "NZBgeek"
+        assert item["query"] == "Breaking Bad"
+        assert item["eventType"] == "grabRelease"
+        assert item["successful"] is True
+        assert item["source"] == "Sonarr"
+
+    async def test_categories_split_and_stripped(self, connector):
+        record = {**_RAW_RECORD, "data": {"categories": " 5000 , 5030 , 2000 "}}
+        connector.get_indexers = AsyncMock(return_value=_INDEXERS)
+        connector.client.get = AsyncMock(return_value=_make_response({"records": [record]}))
+        result = await connector.get_history()
+        assert result[0]["categories"] == ["5000", "5030", "2000"]
+
+    async def test_unknown_indexer_id_uses_hash_fallback(self, connector):
+        connector.get_indexers = AsyncMock(return_value=[])
+        connector.client.get = AsyncMock(return_value=_make_response({"records": [_RAW_RECORD]}))
+        result = await connector.get_history()
+        assert result[0]["indexer"] == "#1"
+
+    async def test_null_indexer_id_gives_empty_string(self, connector):
+        record = {**_RAW_RECORD, "indexerId": None}
+        connector.get_indexers = AsyncMock(return_value=_INDEXERS)
+        connector.client.get = AsyncMock(return_value=_make_response({"records": [record]}))
+        result = await connector.get_history()
+        assert result[0]["indexer"] == ""
+
+    async def test_empty_records_returns_empty_list(self, connector):
+        connector.get_indexers = AsyncMock(return_value=_INDEXERS)
+        connector.client.get = AsyncMock(return_value=_make_response({"records": []}))
+        result = await connector.get_history()
+        assert result == []
+
+    async def test_exception_returns_empty_list(self, connector):
+        connector.get_indexers = AsyncMock(return_value=_INDEXERS)
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.get_history()
+        assert result == []
+
+
+# ── search ────────────────────────────────────────────────────────────────────
+
+
+_RAW_SEARCH_RESULT = {
+    "guid": "magnet:?xt=urn:btih:abc",
+    "title": "Breaking Bad S01E01",
+    "indexer": "NZBgeek",
+    "indexerId": 1,
+    "size": 1_500_000_000,
+    "seeders": 42,
+    "leechers": 5,
+    "protocol": "torrent",
+    "publishDate": "2024-01-10T00:00:00Z",
+    "categories": [{"name": "TV"}, {"name": "HD"}],
+    "downloadUrl": "http://nzbgeek.com/download/abc",
+    "magnetUrl": "magnet:?xt=urn:btih:abc",
+}
+
+
+class TestSearch:
+    async def test_returns_mapped_results(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response([_RAW_SEARCH_RESULT]))
+        result = await connector.search("Breaking Bad")
+        assert len(result) == 1
+        item = result[0]
+        assert item["guid"] == "magnet:?xt=urn:btih:abc"
+        assert item["title"] == "Breaking Bad S01E01"
+        assert item["seeders"] == 42
+        assert item["leechers"] == 5
+        assert item["categories"] == ["TV", "HD"]
+        assert item["downloadUrl"] == "http://nzbgeek.com/download/abc"
+        assert item["magnetUrl"] == "magnet:?xt=urn:btih:abc"
+
+    async def test_empty_results_returns_empty_list(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response([]))
+        result = await connector.search("nothing")
+        assert result == []
+
+    async def test_exception_returns_empty_list(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.search("anything")
+        assert result == []
+
+    async def test_passes_query_and_type_as_params(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response([]))
+        await connector.search("Inception", search_type="movie")
+        call_params = connector.client.get.call_args.kwargs["params"]
+        assert call_params["query"] == "Inception"
+        assert call_params["type"] == "movie"
+
+
+# ── grab ──────────────────────────────────────────────────────────────────────
+
+
+class TestGrab:
+    async def test_success_returns_true(self, connector):
+        connector.client.post = AsyncMock(return_value=_make_response({}))
+        result = await connector.grab("magnet:?xt=urn:btih:abc", indexer_id=1)
+        assert result is True
+
+    async def test_failure_returns_false(self, connector):
+        connector.client.post = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.grab("magnet:?xt=urn:btih:abc", indexer_id=1)
+        assert result is False
+
+    async def test_posts_correct_payload(self, connector):
+        connector.client.post = AsyncMock(return_value=_make_response({}))
+        await connector.grab("some-guid", indexer_id=7)
+        payload = connector.client.post.call_args.kwargs["json"]
+        assert payload["guid"] == "some-guid"
+        assert payload["indexerId"] == 7

--- a/backend/tests/test_prowlarr_routes.py
+++ b/backend/tests/test_prowlarr_routes.py
@@ -1,0 +1,264 @@
+"""
+Integration tests for /api/prowlarr routes.
+
+Covers:
+- GET  /api/prowlarr/indexers
+- PATCH /api/prowlarr/indexers/{id}
+- GET  /api/prowlarr/history
+- GET  /api/prowlarr/search
+- POST /api/prowlarr/grab
+
+Each route is tested for:
+- 503 when Prowlarr service is not configured / inactive
+- Happy path (connector mocked)
+- Error path (connector returns failure / raises)
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from app.models.enums import ServiceType
+
+MOCK_INDEXER = {
+    "id": 1,
+    "name": "NZBgeek",
+    "enable": True,
+    "protocol": "usenet",
+    "privacy": "private",
+    "capabilities": {"categories": ["Movies", "TV"]},
+    "stats": {
+        "numberOfQueries": 50,
+        "numberOfFailedQueries": 2,
+        "numberOfGrabs": 10,
+        "numberOfFailedGrabs": 0,
+        "averageResponseTime": 300,
+    },
+}
+
+MOCK_HISTORY_ITEM = {
+    "id": 1,
+    "date": "2024-01-15T10:00:00Z",
+    "indexer": "NZBgeek",
+    "query": "Breaking Bad",
+    "categories": ["5000"],
+    "eventType": "grabRelease",
+    "successful": True,
+    "source": "Sonarr",
+}
+
+MOCK_SEARCH_RESULT = {
+    "guid": "magnet:?xt=urn:btih:abc",
+    "title": "Breaking Bad S01E01",
+    "indexer": "NZBgeek",
+    "indexerId": 1,
+    "size": 1_500_000_000,
+    "seeders": 42,
+    "leechers": 5,
+    "protocol": "torrent",
+    "publishDate": "2024-01-10T00:00:00Z",
+    "categories": ["TV"],
+    "downloadUrl": "http://example.com/dl",
+    "magnetUrl": "magnet:?xt=urn:btih:abc",
+}
+
+
+_SENTINEL = object()
+
+
+def _mock_connector(
+    indexers=_SENTINEL,
+    history=_SENTINEL,
+    search_results=_SENTINEL,
+    toggle_ok=True,
+    grab_ok=True,
+):
+    m = AsyncMock()
+    m.get_indexers_with_stats = AsyncMock(return_value=[MOCK_INDEXER] if indexers is _SENTINEL else indexers)
+    m.toggle_indexer = AsyncMock(return_value=toggle_ok)
+    m.get_history = AsyncMock(return_value=[MOCK_HISTORY_ITEM] if history is _SENTINEL else history)
+    m.search = AsyncMock(return_value=[MOCK_SEARCH_RESULT] if search_results is _SENTINEL else search_results)
+    m.grab = AsyncMock(return_value=grab_ok)
+    m.close = AsyncMock()
+    return m
+
+
+# ── GET /api/prowlarr/indexers ────────────────────────────────────────────────
+
+
+class TestGetIndexers:
+    def test_no_service_returns_503(self, auth_client):
+        resp = auth_client.get("/api/prowlarr/indexers")
+        assert resp.status_code == 503
+
+    def test_inactive_service_returns_503(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR, is_active=False)
+        resp = auth_client.get("/api/prowlarr/indexers")
+        assert resp.status_code == 503
+
+    def test_returns_indexers(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector()):
+            resp = auth_client.get("/api/prowlarr/indexers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["name"] == "NZBgeek"
+        assert data[0]["stats"]["numberOfQueries"] == 50
+
+    def test_returns_empty_list_when_no_indexers(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector(indexers=[])):
+            resp = auth_client.get("/api/prowlarr/indexers")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ── PATCH /api/prowlarr/indexers/{id} ────────────────────────────────────────
+
+
+class TestToggleIndexer:
+    def test_no_service_returns_503(self, auth_client):
+        resp = auth_client.patch("/api/prowlarr/indexers/1", json={"enable": True})
+        assert resp.status_code == 503
+
+    def test_toggle_enable_returns_success(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector(toggle_ok=True)):
+            resp = auth_client.patch("/api/prowlarr/indexers/1", json={"enable": True})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["success"] is True
+        assert data["id"] == 1
+        assert data["enable"] is True
+
+    def test_toggle_disable_reflects_in_response(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector(toggle_ok=True)):
+            resp = auth_client.patch("/api/prowlarr/indexers/5", json={"enable": False})
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["id"] == 5
+        assert data["enable"] is False
+
+    def test_connector_failure_returns_502(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector(toggle_ok=False)):
+            resp = auth_client.patch("/api/prowlarr/indexers/1", json={"enable": True})
+        assert resp.status_code == 502
+
+
+# ── GET /api/prowlarr/history ─────────────────────────────────────────────────
+
+
+class TestGetHistory:
+    def test_no_service_returns_503(self, auth_client):
+        resp = auth_client.get("/api/prowlarr/history")
+        assert resp.status_code == 503
+
+    def test_returns_history_items(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector()):
+            resp = auth_client.get("/api/prowlarr/history")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["indexer"] == "NZBgeek"
+        assert data[0]["query"] == "Breaking Bad"
+
+    def test_default_limit_is_15(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        mock = _mock_connector()
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=mock):
+            auth_client.get("/api/prowlarr/history")
+        mock.get_history.assert_called_once_with(page_size=15)
+
+    def test_custom_limit_passed_to_connector(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        mock = _mock_connector()
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=mock):
+            auth_client.get("/api/prowlarr/history?limit=50")
+        mock.get_history.assert_called_once_with(page_size=50)
+
+    def test_limit_too_large_returns_422(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        resp = auth_client.get("/api/prowlarr/history?limit=999")
+        assert resp.status_code == 422
+
+    def test_limit_zero_returns_422(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        resp = auth_client.get("/api/prowlarr/history?limit=0")
+        assert resp.status_code == 422
+
+
+# ── GET /api/prowlarr/search ──────────────────────────────────────────────────
+
+
+class TestSearch:
+    def test_no_service_returns_503(self, auth_client):
+        resp = auth_client.get("/api/prowlarr/search?query=test")
+        assert resp.status_code == 503
+
+    def test_returns_search_results(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector()):
+            resp = auth_client.get("/api/prowlarr/search?query=Breaking+Bad")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]["title"] == "Breaking Bad S01E01"
+        assert data[0]["seeders"] == 42
+
+    def test_missing_query_returns_422(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        resp = auth_client.get("/api/prowlarr/search")
+        assert resp.status_code == 422
+
+    def test_empty_query_returns_422(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        resp = auth_client.get("/api/prowlarr/search?query=")
+        assert resp.status_code == 422
+
+    def test_passes_type_param_to_connector(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        mock = _mock_connector()
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=mock):
+            auth_client.get("/api/prowlarr/search?query=test&type=movie")
+        mock.search.assert_called_once_with("test", "movie")
+
+    def test_empty_results_returns_empty_list(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector(search_results=[])):
+            resp = auth_client.get("/api/prowlarr/search?query=nothing")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+
+# ── POST /api/prowlarr/grab ───────────────────────────────────────────────────
+
+
+class TestGrab:
+    def test_no_service_returns_503(self, auth_client):
+        resp = auth_client.post("/api/prowlarr/grab", json={"guid": "abc", "indexerId": 1})
+        assert resp.status_code == 503
+
+    def test_success_returns_ok(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector(grab_ok=True)):
+            resp = auth_client.post("/api/prowlarr/grab", json={"guid": "magnet:abc", "indexerId": 1})
+        assert resp.status_code == 200
+        assert resp.json() == {"success": True}
+
+    def test_connector_failure_returns_502(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        with patch("app.api.routes.prowlarr.ProwlarrConnector", return_value=_mock_connector(grab_ok=False)):
+            resp = auth_client.post("/api/prowlarr/grab", json={"guid": "magnet:abc", "indexerId": 1})
+        assert resp.status_code == 502
+
+    def test_missing_guid_returns_422(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        resp = auth_client.post("/api/prowlarr/grab", json={"indexerId": 1})
+        assert resp.status_code == 422
+
+    def test_missing_indexer_id_returns_422(self, auth_client, make_service_config):
+        make_service_config(service_name=ServiceType.PROWLARR)
+        resp = auth_client.post("/api/prowlarr/grab", json={"guid": "abc"})
+        assert resp.status_code == 422

--- a/backend/tests/test_radarr_connector.py
+++ b/backend/tests/test_radarr_connector.py
@@ -1,0 +1,332 @@
+"""
+Unit tests for RadarrConnector.
+
+Covers:
+- test_connection: success and failure
+- get_movies: returns list, handles exception
+- get_calendar: date params, exception handling
+- get_recent_additions: date filtering, sorting, invalid dates ignored
+- get_history: returns records, handles exception
+- get_movie_history_map: builds {movieId: hash} map
+- _extract_hash: all formats and edge cases
+- get_quality_profiles: mapping, exception handling
+- get_statistics: correct counts, exception handling
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "3306")
+os.environ.setdefault("DB_USER", "test")
+os.environ.setdefault("DB_PASSWORD", "test")
+os.environ.setdefault("DB_NAME", "test")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-pilotarr-testing-only!")
+os.environ.setdefault("API_KEY", "test-api-key")
+os.environ.setdefault("WEBHOOK_SECRET", "test-webhook-secret")
+
+from app.services.radarr_connector import RadarrConnector  # noqa: E402
+
+
+def _make_response(data, status_code=200):
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.json.return_value = data
+    mock.raise_for_status = MagicMock()
+    return mock
+
+
+@pytest.fixture()
+def connector():
+    return RadarrConnector(base_url="http://radarr", api_key="test-key", port=7878)
+
+
+# ── Init ──────────────────────────────────────────────────────────────────────
+
+
+class TestInit:
+    def test_port_appended_to_base_url(self):
+        c = RadarrConnector(base_url="http://radarr", api_key="key", port=7878)
+        assert c.base_url == "http://radarr:7878"
+
+    def test_api_key_in_headers(self, connector):
+        headers = connector._get_headers()
+        assert headers["X-Api-Key"] == "test-key"
+
+
+# ── test_connection ───────────────────────────────────────────────────────────
+
+
+class TestTestConnection:
+    async def test_success_returns_true_with_version(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response({"version": "5.1.0"}))
+        ok, msg = await connector.test_connection()
+        assert ok is True
+        assert "5.1.0" in msg
+
+    async def test_failure_returns_false(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        ok, msg = await connector.test_connection()
+        assert ok is False
+        assert "Erreur" in msg
+
+
+# ── get_movies ────────────────────────────────────────────────────────────────
+
+
+class TestGetMovies:
+    async def test_returns_movie_list(self, connector):
+        payload = [{"id": 1, "title": "Inception"}, {"id": 2, "title": "The Matrix"}]
+        connector.client.get = AsyncMock(return_value=_make_response(payload))
+        result = await connector.get_movies()
+        assert len(result) == 2
+        assert result[0]["title"] == "Inception"
+
+    async def test_exception_returns_empty_list(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.get_movies()
+        assert result == []
+
+
+# ── get_calendar ──────────────────────────────────────────────────────────────
+
+
+class TestGetCalendar:
+    async def test_returns_calendar_list(self, connector):
+        payload = [{"id": 1, "title": "New Movie", "inCinemas": "2024-02-01"}]
+        connector.client.get = AsyncMock(return_value=_make_response(payload))
+        result = await connector.get_calendar()
+        assert len(result) == 1
+        assert result[0]["title"] == "New Movie"
+
+    async def test_passes_date_params(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response([]))
+        await connector.get_calendar(days_ahead=14, days_behind=7)
+        call_params = connector.client.get.call_args.kwargs["params"]
+        assert "start" in call_params
+        assert "end" in call_params
+
+    async def test_exception_returns_empty_list(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.get_calendar()
+        assert result == []
+
+
+# ── get_recent_additions ──────────────────────────────────────────────────────
+
+
+class TestGetRecentAdditions:
+    def _recent_movie(self, title, days_ago=1):
+        added = (datetime.now(UTC) - timedelta(days=days_ago)).isoformat()
+        return {"id": 1, "title": title, "added": added, "hasFile": True, "monitored": True}
+
+    def _old_movie(self, title):
+        added = (datetime.now(UTC) - timedelta(days=30)).isoformat()
+        return {"id": 2, "title": title, "added": added, "hasFile": True, "monitored": True}
+
+    async def test_filters_by_days(self, connector):
+        movies = [self._recent_movie("New"), self._old_movie("Old")]
+        connector.get_movies = AsyncMock(return_value=movies)
+        result = await connector.get_recent_additions(days=7)
+        assert len(result) == 1
+        assert result[0]["title"] == "New"
+
+    async def test_sorted_most_recent_first(self, connector):
+        m1 = self._recent_movie("Earlier", days_ago=3)
+        m2 = self._recent_movie("Latest", days_ago=1)
+        connector.get_movies = AsyncMock(return_value=[m1, m2])
+        result = await connector.get_recent_additions(days=7)
+        assert result[0]["title"] == "Latest"
+
+    async def test_movies_without_added_field_are_skipped(self, connector):
+        movie = {"id": 1, "title": "No Date", "hasFile": True, "monitored": True}
+        connector.get_movies = AsyncMock(return_value=[movie])
+        result = await connector.get_recent_additions(days=7)
+        assert result == []
+
+    async def test_invalid_date_format_is_skipped(self, connector):
+        movie = {"id": 1, "title": "Bad Date", "added": "not-a-date"}
+        connector.get_movies = AsyncMock(return_value=[movie])
+        result = await connector.get_recent_additions(days=7)
+        assert result == []
+
+    async def test_exception_returns_empty_list(self, connector):
+        connector.get_movies = AsyncMock(side_effect=Exception("fail"))
+        result = await connector.get_recent_additions()
+        assert result == []
+
+
+# ── get_history ───────────────────────────────────────────────────────────────
+
+
+class TestGetHistory:
+    async def test_returns_records(self, connector):
+        payload = {"records": [{"id": 1, "movieId": 10, "downloadId": "abc123"}]}
+        connector.client.get = AsyncMock(return_value=_make_response(payload))
+        result = await connector.get_history(page_size=10)
+        assert len(result) == 1
+        assert result[0]["movieId"] == 10
+
+    async def test_empty_records_returns_empty_list(self, connector):
+        connector.client.get = AsyncMock(return_value=_make_response({"records": []}))
+        result = await connector.get_history()
+        assert result == []
+
+    async def test_exception_returns_empty_list(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.get_history()
+        assert result == []
+
+
+# ── get_movie_history_map ─────────────────────────────────────────────────────
+
+
+class TestGetMovieHistoryMap:
+    async def test_builds_movie_hash_map(self, connector):
+        records = [
+            {"movieId": 1, "downloadId": "qBittorrent-" + "a" * 40},
+            {"movieId": 2, "downloadId": "b" * 40},
+        ]
+        connector.get_history = AsyncMock(return_value=records)
+        result = await connector.get_movie_history_map()
+        assert 1 in result
+        assert 2 in result
+        assert result[1] == "A" * 40
+        assert result[2] == "B" * 40
+
+    async def test_skips_records_without_valid_hash(self, connector):
+        records = [
+            {"movieId": 1, "downloadId": "invalid"},
+            {"movieId": 2, "downloadId": ""},
+        ]
+        connector.get_history = AsyncMock(return_value=records)
+        result = await connector.get_movie_history_map()
+        assert result == {}
+
+    async def test_skips_records_without_movie_id(self, connector):
+        records = [{"downloadId": "a" * 40}]
+        connector.get_history = AsyncMock(return_value=records)
+        result = await connector.get_movie_history_map()
+        assert result == {}
+
+    async def test_later_record_overwrites_earlier_for_same_movie(self, connector):
+        hash1 = "a" * 40
+        hash2 = "b" * 40
+        records = [
+            {"movieId": 1, "downloadId": hash1},
+            {"movieId": 1, "downloadId": hash2},
+        ]
+        connector.get_history = AsyncMock(return_value=records)
+        result = await connector.get_movie_history_map()
+        # Last one wins
+        assert result[1] == hash2.upper()
+
+
+# ── _extract_hash ─────────────────────────────────────────────────────────────
+
+
+class TestExtractHash:
+    def test_qbittorrent_prefixed_format(self, connector):
+        result = connector._extract_hash("qBittorrent-" + "a" * 40)
+        assert result == "A" * 40
+
+    def test_bare_40_char_hex(self, connector):
+        raw = "a" * 40
+        assert connector._extract_hash(raw) == raw.upper()
+
+    def test_uppercase_hex_accepted(self, connector):
+        raw = "A" * 40
+        assert connector._extract_hash(raw) == raw
+
+    def test_returns_none_for_empty_string(self, connector):
+        assert connector._extract_hash("") is None
+
+    def test_returns_none_for_none(self, connector):
+        assert connector._extract_hash(None) is None
+
+    def test_returns_none_for_short_string(self, connector):
+        assert connector._extract_hash("tooshort") is None
+
+    def test_returns_none_for_non_hex_40_chars(self, connector):
+        assert connector._extract_hash("z" * 40) is None
+
+    def test_result_is_always_uppercase(self, connector):
+        raw = "abcdef1234567890abcdef1234567890abcdef12"
+        result = connector._extract_hash(raw)
+        assert result == raw.upper()
+
+    def test_prefix_part_is_discarded(self, connector):
+        hash_part = "a" * 40
+        result = connector._extract_hash(f"Radarr-{hash_part}")
+        assert result == hash_part.upper()
+
+
+# ── get_quality_profiles ──────────────────────────────────────────────────────
+
+
+class TestGetQualityProfiles:
+    async def test_returns_id_name_mapping(self, connector):
+        payload = [{"id": 1, "name": "HD-1080p"}, {"id": 2, "name": "4K"}]
+        connector.client.get = AsyncMock(return_value=_make_response(payload))
+        result = await connector.get_quality_profiles()
+        assert result == {1: "HD-1080p", 2: "4K"}
+
+    async def test_skips_profiles_without_id_or_name(self, connector):
+        payload = [{"id": 1, "name": "Valid"}, {"id": 2}, {"name": "No ID"}]
+        connector.client.get = AsyncMock(return_value=_make_response(payload))
+        result = await connector.get_quality_profiles()
+        assert result == {1: "Valid"}
+
+    async def test_exception_returns_empty_dict(self, connector):
+        connector.client.get = AsyncMock(side_effect=httpx.ConnectError("refused"))
+        result = await connector.get_quality_profiles()
+        assert result == {}
+
+
+# ── get_statistics ────────────────────────────────────────────────────────────
+
+
+class TestGetStatistics:
+    _MOVIES = [
+        {"id": 1, "title": "A", "monitored": True, "hasFile": True},
+        {"id": 2, "title": "B", "monitored": True, "hasFile": False},
+        {"id": 3, "title": "C", "monitored": False, "hasFile": True},
+        {"id": 4, "title": "D", "monitored": False, "hasFile": False},
+    ]
+
+    async def test_counts_are_correct(self, connector):
+        connector.get_movies = AsyncMock(return_value=self._MOVIES)
+        result = await connector.get_statistics()
+        assert result["total_movies"] == 4
+        assert result["monitored_movies"] == 2
+        assert result["downloaded_movies"] == 2
+        assert result["missing_movies"] == 0  # monitored=2, downloaded=2
+
+    async def test_missing_movies_is_monitored_minus_downloaded(self, connector):
+        movies = [
+            {"id": 1, "monitored": True, "hasFile": False},
+            {"id": 2, "monitored": True, "hasFile": False},
+            {"id": 3, "monitored": True, "hasFile": True},
+        ]
+        connector.get_movies = AsyncMock(return_value=movies)
+        result = await connector.get_statistics()
+        assert result["missing_movies"] == 2
+
+    async def test_empty_library_returns_zeros(self, connector):
+        connector.get_movies = AsyncMock(return_value=[])
+        result = await connector.get_statistics()
+        assert result == {
+            "total_movies": 0,
+            "monitored_movies": 0,
+            "downloaded_movies": 0,
+            "missing_movies": 0,
+        }
+
+    async def test_exception_returns_empty_dict(self, connector):
+        connector.get_movies = AsyncMock(side_effect=Exception("fail"))
+        result = await connector.get_statistics()
+        assert result == {}

--- a/backend/tests/test_services_routes.py
+++ b/backend/tests/test_services_routes.py
@@ -1,9 +1,7 @@
 """
 Integration tests for /api/services routes.
 
-- GET  /api/services/
 - GET  /api/services/{name}
-- POST /api/services/
 - PUT  /api/services/{name}
 - DELETE /api/services/{name}
 - POST /api/services/{name}/test
@@ -12,22 +10,6 @@ Integration tests for /api/services routes.
 from unittest.mock import AsyncMock, patch
 
 from app.models.enums import ServiceType
-
-# ── GET /api/services/ ────────────────────────────────────────────────────────
-
-
-class TestListServices:
-    def test_empty(self, auth_client):
-        resp = auth_client.get("/api/services/")
-        assert resp.status_code == 200
-        assert resp.json() == []
-
-    def test_with_one_service(self, auth_client, make_service_config):
-        make_service_config()
-        resp = auth_client.get("/api/services/")
-        assert resp.status_code == 200
-        assert len(resp.json()) == 1
-
 
 # ── GET /api/services/{name} ──────────────────────────────────────────────────
 
@@ -60,36 +42,6 @@ class TestGetService:
     def test_get_nonexistent(self, auth_client):
         resp = auth_client.get("/api/services/sonarr")
         assert resp.status_code == 404
-
-
-# ── POST /api/services/ ───────────────────────────────────────────────────────
-
-
-class TestCreateService:
-    def test_create_new_service(self, auth_client):
-        payload = {
-            "service_name": "sonarr",
-            "url": "http://sonarr",
-            "api_key": "sonarr-key",
-            "port": 8989,
-            "is_active": True,
-        }
-        resp = auth_client.post("/api/services/", json=payload)
-        assert resp.status_code == 201
-        data = resp.json()
-        assert data["service_name"] == "sonarr"
-        assert data["url"] == "http://sonarr"
-
-    def test_create_duplicate_service(self, auth_client, make_service_config):
-        make_service_config(service_name=ServiceType.SONARR)
-        payload = {
-            "service_name": "sonarr",
-            "url": "http://sonarr2",
-            "api_key": "key2",
-            "is_active": True,
-        }
-        resp = auth_client.post("/api/services/", json=payload)
-        assert resp.status_code == 409
 
 
 # ── PUT /api/services/{name} ──────────────────────────────────────────────────

--- a/backend/tests/test_sync_service.py
+++ b/backend/tests/test_sync_service.py
@@ -1,0 +1,826 @@
+"""
+Unit/integration tests for SyncService.
+
+Covers:
+- get_active_service: returns active config, ignores inactive
+- _upsert_torrent: insert once, idempotent on duplicate
+- update_sync_metadata: create new entry, update existing
+- _format_time_ago: all time buckets (days, hours, minutes, just now)
+- sync_radarr: no service, new movie inserted, existing movie updated, calendar events
+- sync_sonarr: no service, new series inserted, existing updated, calendar events
+- sync_sonarr_seasons: no service, seasons created and updated
+- sync_sonarr_episodes: no service, no series, episodes created and updated
+- sync_monitored_items: aggregates Radarr+Sonarr stats into DashboardStatistic
+- sync_jellyfin: no service, creates user/movie/tv dashboard stats
+- sync_jellyseerr: no service, adds requests, updates existing, deletes stale
+"""
+
+import os
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+os.environ.setdefault("DB_HOST", "localhost")
+os.environ.setdefault("DB_PORT", "3306")
+os.environ.setdefault("DB_USER", "test")
+os.environ.setdefault("DB_PASSWORD", "test")
+os.environ.setdefault("DB_NAME", "test")
+os.environ.setdefault("SECRET_KEY", "test-secret-key-for-pilotarr-testing-only!")
+os.environ.setdefault("API_KEY", "test-api-key")
+os.environ.setdefault("WEBHOOK_SECRET", "test-webhook-secret")
+
+from app.models import (  # noqa: E402
+    CalendarEvent,
+    DashboardStatistic,
+    Episode,
+    JellyseerrRequest,
+    LibraryItem,
+    LibraryItemTorrent,
+    MediaType,
+    Season,
+    ServiceConfiguration,
+    ServiceType,
+    StatType,
+    SyncMetadata,
+    SyncStatus,
+)
+from app.schedulers.sync_service import SyncService  # noqa: E402
+
+
+@pytest.fixture()
+def sync(db):
+    return SyncService(db=db)
+
+
+def _make_svc(db, service_type, is_active=True):
+    svc = ServiceConfiguration(
+        service_name=service_type,
+        url="http://localhost",
+        port=7878,
+        api_key="key",
+        is_active=is_active,
+    )
+    db.add(svc)
+    db.commit()
+    db.refresh(svc)
+    return svc
+
+
+# ── get_active_service ────────────────────────────────────────────────────────
+
+
+class TestGetActiveService:
+    def test_returns_active_service(self, sync, db):
+        _make_svc(db, ServiceType.RADARR, is_active=True)
+        svc = sync.get_active_service(ServiceType.RADARR)
+        assert svc is not None
+        assert svc.service_name == ServiceType.RADARR
+
+    def test_returns_none_when_inactive(self, sync, db):
+        _make_svc(db, ServiceType.RADARR, is_active=False)
+        svc = sync.get_active_service(ServiceType.RADARR)
+        assert svc is None
+
+    def test_returns_none_when_not_configured(self, sync):
+        svc = sync.get_active_service(ServiceType.RADARR)
+        assert svc is None
+
+
+# ── _upsert_torrent ───────────────────────────────────────────────────────────
+
+
+class TestUpsertTorrent:
+    def test_inserts_new_torrent(self, sync, db, make_library_item):
+        item = make_library_item()
+        sync._upsert_torrent(item.id, "a" * 40)
+        db.commit()
+        row = db.query(LibraryItemTorrent).filter_by(library_item_id=item.id).first()
+        assert row is not None
+        assert row.torrent_hash == "a" * 40
+
+    def test_idempotent_on_duplicate(self, sync, db, make_library_item):
+        item = make_library_item()
+        sync._upsert_torrent(item.id, "b" * 40)
+        db.commit()
+        sync._upsert_torrent(item.id, "b" * 40)
+        db.commit()
+        count = db.query(LibraryItemTorrent).filter_by(library_item_id=item.id).count()
+        assert count == 1
+
+    def test_different_hashes_both_inserted(self, sync, db, make_library_item):
+        item = make_library_item()
+        sync._upsert_torrent(item.id, "a" * 40)
+        sync._upsert_torrent(item.id, "b" * 40)
+        db.commit()
+        count = db.query(LibraryItemTorrent).filter_by(library_item_id=item.id).count()
+        assert count == 2
+
+    def test_stores_episode_and_season_metadata(self, sync, db, make_library_item):
+        item = make_library_item()
+        sync._upsert_torrent(item.id, "c" * 40, episode_id=5, season_number=2, is_season_pack=True)
+        db.commit()
+        row = db.query(LibraryItemTorrent).filter_by(library_item_id=item.id).first()
+        assert row.episode_id == 5
+        assert row.season_number == 2
+        assert row.is_season_pack is True
+
+
+# ── update_sync_metadata ──────────────────────────────────────────────────────
+
+
+class TestUpdateSyncMetadata:
+    def test_creates_new_entry(self, sync, db):
+        sync.update_sync_metadata(ServiceType.RADARR, SyncStatus.SUCCESS, records=5, duration_ms=100)
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.RADARR).first()
+        assert meta is not None
+        assert meta.sync_status == SyncStatus.SUCCESS
+        assert meta.records_synced == 5
+        assert meta.sync_duration_ms == 100
+
+    def test_updates_existing_entry(self, sync, db):
+        sync.update_sync_metadata(ServiceType.RADARR, SyncStatus.SUCCESS, records=1)
+        sync.update_sync_metadata(ServiceType.RADARR, SyncStatus.FAILED, records=0, error="boom")
+        metas = db.query(SyncMetadata).filter_by(service_name=ServiceType.RADARR).all()
+        assert len(metas) == 1
+        assert metas[0].sync_status == SyncStatus.FAILED
+        assert metas[0].error_message == "boom"
+
+    def test_sets_next_sync_time(self, sync, db):
+        before = datetime.now(UTC).replace(tzinfo=None)
+        sync.update_sync_metadata(ServiceType.SONARR, SyncStatus.SUCCESS)
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.SONARR).first()
+        # SQLite stores naive datetimes; strip tz for comparison
+        next_sync = meta.next_sync_time
+        if next_sync.tzinfo is not None:
+            next_sync = next_sync.replace(tzinfo=None)
+        assert next_sync > before
+
+
+# ── _format_time_ago ──────────────────────────────────────────────────────────
+
+
+class TestFormatTimeAgo:
+    def test_just_now(self, sync):
+        dt = datetime.now(UTC) - timedelta(seconds=30)
+        assert sync._format_time_ago(dt) == "just now"
+
+    def test_minutes(self, sync):
+        dt = datetime.now(UTC) - timedelta(minutes=5)
+        result = sync._format_time_ago(dt)
+        assert "minute" in result
+        assert "5" in result
+
+    def test_one_minute_singular(self, sync):
+        dt = datetime.now(UTC) - timedelta(minutes=1)
+        result = sync._format_time_ago(dt)
+        assert result == "1 minute ago"
+
+    def test_hours(self, sync):
+        dt = datetime.now(UTC) - timedelta(hours=3)
+        result = sync._format_time_ago(dt)
+        assert "3 hour" in result
+
+    def test_one_hour_singular(self, sync):
+        dt = datetime.now(UTC) - timedelta(hours=1)
+        assert sync._format_time_ago(dt) == "1 hour ago"
+
+    def test_days(self, sync):
+        dt = datetime.now(UTC) - timedelta(days=4)
+        result = sync._format_time_ago(dt)
+        assert "4 day" in result
+
+    def test_one_day_singular(self, sync):
+        dt = datetime.now(UTC) - timedelta(days=1)
+        assert sync._format_time_ago(dt) == "1 day ago"
+
+    def test_naive_datetime_handled(self, sync):
+        dt = datetime.utcnow() - timedelta(hours=2)  # naive
+        result = sync._format_time_ago(dt)
+        assert "hour" in result
+
+
+# ── sync_radarr ───────────────────────────────────────────────────────────────
+
+_RADARR_MOVIE = {
+    "id": 1,
+    "title": "Inception",
+    "year": 2010,
+    "overview": "A mind-bending thriller.",
+    "added": "2024-01-10T00:00:00Z",
+    "sizeOnDisk": 4_294_967_296,
+    "hasFile": True,
+    "monitored": True,
+    "qualityProfileId": 1,
+    "images": [{"coverType": "poster", "remoteUrl": "http://example.com/poster.jpg"}],
+    "movieFile": {
+        "path": "/movies/Inception/Inception.mkv",
+        "quality": {"quality": {"name": "Bluray-1080p"}},
+    },
+    "ratings": {"imdb": {"value": 8.8}},
+}
+
+_RADARR_CALENDAR_EVENT = {
+    "title": "Dune Part 3",
+    "physicalRelease": "2025-06-01T00:00:00Z",
+    "images": [{"coverType": "poster", "remoteUrl": "http://example.com/dune.jpg"}],
+}
+
+
+def _mock_radarr_connector(movies=None, calendar=None, quality_profiles=None, hash_map=None):
+    m = AsyncMock()
+    m.get_movies = AsyncMock(return_value=movies if movies is not None else [_RADARR_MOVIE])
+    m.get_quality_profiles = AsyncMock(return_value=quality_profiles or {1: "HD-1080p"})
+    m.get_movie_history_map = AsyncMock(return_value=hash_map or {1: "a" * 40})
+    m.get_calendar = AsyncMock(return_value=calendar if calendar is not None else [_RADARR_CALENDAR_EVENT])
+    m.get_statistics = AsyncMock(
+        return_value={"monitored_movies": 2, "total_movies": 3, "downloaded_movies": 2, "missing_movies": 0}
+    )
+    m.close = AsyncMock()
+    return m
+
+
+class TestSyncRadarr:
+    async def test_no_service_returns_failure(self, sync):
+        result = await sync.sync_radarr()
+        assert result["success"] is False
+
+    async def test_creates_new_movie_in_db(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=_mock_radarr_connector()):
+            result = await sync.sync_radarr()
+        assert result["success"] is True
+        assert result["movies_added"] == 1
+        item = db.query(LibraryItem).filter_by(title="Inception").first()
+        assert item is not None
+        assert item.media_type == MediaType.MOVIE
+        assert item.year == 2010
+
+    async def test_resolves_quality_from_file(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=_mock_radarr_connector()):
+            await sync.sync_radarr()
+        item = db.query(LibraryItem).filter_by(title="Inception").first()
+        assert item.quality == "Bluray-1080p"
+
+    async def test_stores_torrent_hash(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=_mock_radarr_connector()):
+            await sync.sync_radarr()
+        item = db.query(LibraryItem).filter_by(title="Inception").first()
+        torrent = db.query(LibraryItemTorrent).filter_by(library_item_id=item.id).first()
+        assert torrent is not None
+
+    async def test_updates_existing_movie(self, sync, db, make_library_item):
+        _make_svc(db, ServiceType.RADARR)
+        make_library_item(title="Inception", year=2010, media_type=MediaType.MOVIE, quality="720p")
+        mock = _mock_radarr_connector()
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=mock):
+            result = await sync.sync_radarr()
+        assert result["movies_added"] == 0  # not added again
+        item = db.query(LibraryItem).filter_by(title="Inception").first()
+        assert item.nb_media == 1  # updated
+
+    async def test_creates_calendar_event(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=_mock_radarr_connector()):
+            result = await sync.sync_radarr()
+        assert result["calendar_events"] == 1
+        cal = db.query(CalendarEvent).filter_by(title="Dune Part 3").first()
+        assert cal is not None
+        assert cal.media_type == MediaType.MOVIE
+
+    async def test_calendar_event_deduplication(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        mock = _mock_radarr_connector()
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=mock):
+            await sync.sync_radarr()
+            await sync.sync_radarr()
+        count = db.query(CalendarEvent).filter_by(title="Dune Part 3").count()
+        assert count == 1
+
+    async def test_skips_calendar_event_without_release_date(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        event = {"title": "No Date Movie", "images": []}
+        mock = _mock_radarr_connector(calendar=[event])
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=mock):
+            result = await sync.sync_radarr()
+        assert result["calendar_events"] == 0
+
+    async def test_writes_sync_metadata_on_success(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=_mock_radarr_connector()):
+            await sync.sync_radarr()
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.RADARR).first()
+        assert meta.sync_status == SyncStatus.SUCCESS
+
+    async def test_writes_sync_metadata_on_failure(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        mock = _mock_radarr_connector()
+        mock.get_movies = AsyncMock(side_effect=Exception("API down"))
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=mock):
+            result = await sync.sync_radarr()
+        assert result["success"] is False
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.RADARR).first()
+        assert meta.sync_status == SyncStatus.FAILED
+
+
+# ── sync_sonarr ───────────────────────────────────────────────────────────────
+
+_SONARR_SERIES = {
+    "id": 10,
+    "title": "Breaking Bad",
+    "year": 2008,
+    "overview": "A chemistry teacher goes bad.",
+    "added": "2024-01-05T00:00:00Z",
+    "qualityProfileId": 1,
+    "path": "/series/BreakingBad",
+    "images": [{"coverType": "poster", "remoteUrl": "http://example.com/bb.jpg"}],
+    "statistics": {"episodeFileCount": 62, "sizeOnDisk": 10_737_418_240},
+    "ratings": {"value": 9.5},
+    "seasons": [
+        {
+            "seasonNumber": 1,
+            "monitored": True,
+            "statistics": {"episodeCount": 7, "episodeFileCount": 7, "totalEpisodeCount": 7, "sizeOnDisk": 0},
+        }
+    ],
+}
+
+_SONARR_CALENDAR_EVENT = {
+    "airDate": "2024-06-01",
+    "seasonNumber": 2,
+    "episodeNumber": 1,
+    "title": "Seven Thirty-Seven",
+    "series": {
+        "title": "Breaking Bad",
+        "images": [{"coverType": "poster", "remoteUrl": "http://example.com/bb.jpg"}],
+    },
+}
+
+
+def _mock_sonarr_connector(series=None, calendar=None, quality_profiles=None, torrents_map=None):
+    m = AsyncMock()
+    m.get_series = AsyncMock(return_value=series if series is not None else [_SONARR_SERIES])
+    m.get_quality_profiles = AsyncMock(return_value=quality_profiles or {1: "HD-1080p"})
+    m.get_series_torrents_map = AsyncMock(return_value=torrents_map if torrents_map is not None else {})
+    m.get_calendar = AsyncMock(return_value=calendar if calendar is not None else [_SONARR_CALENDAR_EVENT])
+    m.get_statistics = AsyncMock(
+        return_value={"monitored_series": 3, "total_series": 5, "downloaded_episodes": 100, "missing_episodes": 10}
+    )
+    m.get_episodes_by_series = AsyncMock(return_value=[])
+    m.get_episode_files_by_series = AsyncMock(return_value=[])
+    m.close = AsyncMock()
+    return m
+
+
+class TestSyncSonarr:
+    async def test_no_service_returns_failure(self, sync):
+        result = await sync.sync_sonarr()
+        assert result["success"] is False
+
+    async def test_creates_new_series_in_db(self, sync, db):
+        _make_svc(db, ServiceType.SONARR)
+        mock = _mock_sonarr_connector()
+        # sync_sonarr_seasons also needs the connector — patch it at module level
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr()
+        assert result["success"] is True
+        assert result["series_added"] == 1
+        item = db.query(LibraryItem).filter_by(title="Breaking Bad").first()
+        assert item is not None
+        assert item.media_type == MediaType.TV
+        assert item.year == 2008
+
+    async def test_does_not_duplicate_existing_series(self, sync, db, make_library_item):
+        _make_svc(db, ServiceType.SONARR)
+        make_library_item(title="Breaking Bad", year=2008, media_type=MediaType.TV)
+        mock = _mock_sonarr_connector()
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr()
+        assert result["series_added"] == 0
+        count = db.query(LibraryItem).filter_by(title="Breaking Bad").count()
+        assert count == 1
+
+    async def test_creates_calendar_event(self, sync, db):
+        _make_svc(db, ServiceType.SONARR)
+        mock = _mock_sonarr_connector()
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr()
+        assert result["calendar_events"] == 1
+        cal = db.query(CalendarEvent).filter_by(media_type=MediaType.TV).first()
+        assert cal is not None
+        assert cal.title == "Breaking Bad"
+        assert "S02E01" in cal.episode
+
+    async def test_skips_calendar_event_without_air_date(self, sync, db):
+        _make_svc(db, ServiceType.SONARR)
+        event = {"airDate": None, "seasonNumber": 1, "episodeNumber": 1, "title": "No Air", "series": {}}
+        mock = _mock_sonarr_connector(calendar=[event])
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr()
+        assert result["calendar_events"] == 0
+
+    async def test_writes_sync_metadata_on_success(self, sync, db):
+        _make_svc(db, ServiceType.SONARR)
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=_mock_sonarr_connector()):
+            await sync.sync_sonarr()
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.SONARR).first()
+        assert meta.sync_status == SyncStatus.SUCCESS
+
+
+# ── sync_sonarr_seasons ───────────────────────────────────────────────────────
+
+
+class TestSyncSonarrSeasons:
+    async def test_no_service_returns_failure(self, sync):
+        result = await sync.sync_sonarr_seasons()
+        assert result["success"] is False
+
+    async def test_creates_seasons_for_tv_item(self, sync, db, make_library_item):
+        _make_svc(db, ServiceType.SONARR)
+        make_library_item(title="Breaking Bad", year=2008, media_type=MediaType.TV)
+        mock = _mock_sonarr_connector()
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr_seasons()
+        assert result["success"] is True
+        assert result["seasons_synced"] >= 1
+        season = db.query(Season).first()
+        assert season is not None
+        assert season.season_number == 1
+
+    async def test_updates_existing_season(self, sync, db, make_library_item):
+        _make_svc(db, ServiceType.SONARR)
+        item = make_library_item(title="Breaking Bad", year=2008, media_type=MediaType.TV)
+        existing_season = Season(
+            library_item_id=item.id,
+            sonarr_series_id=10,
+            season_number=1,
+            monitored=False,
+            episode_count=0,
+        )
+        db.add(existing_season)
+        db.commit()
+        mock = _mock_sonarr_connector()
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr_seasons()
+        assert result["seasons_updated"] >= 1
+        db.refresh(existing_season)
+        assert existing_season.episode_count == 7
+
+    async def test_skips_series_not_in_db(self, sync, db):
+        _make_svc(db, ServiceType.SONARR)
+        # DB has no TV items — sonarr returns a series but nothing to match against
+        mock = _mock_sonarr_connector()
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr_seasons()
+        assert result["success"] is True
+        assert result["seasons_synced"] == 0
+
+
+# ── sync_sonarr_episodes ──────────────────────────────────────────────────────
+
+_SONARR_EPISODE = {
+    "id": 101,
+    "seasonNumber": 1,
+    "episodeNumber": 1,
+    "title": "Pilot",
+    "overview": "Walter White starts cooking.",
+    "airDate": "2008-01-20",
+    "monitored": True,
+    "hasFile": True,
+    "episodeFileId": 5,
+    "absoluteEpisodeNumber": 1,
+}
+
+_SONARR_EPISODE_FILE = {
+    "id": 5,
+    "size": 1_073_741_824,
+    "relativePath": "Season 01/bb.s01e01.mkv",
+    "quality": {"quality": {"name": "Bluray-1080p"}},
+}
+
+
+class TestSyncSonarrEpisodes:
+    async def test_no_service_returns_failure(self, sync):
+        result = await sync.sync_sonarr_episodes()
+        assert result["success"] is False
+
+    async def test_no_series_in_db_returns_early(self, sync, db):
+        _make_svc(db, ServiceType.SONARR)
+        mock = _mock_sonarr_connector()
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr_episodes()
+        assert result["success"] is True
+        assert result["episodes_synced"] == 0
+        assert result["series_processed"] == 0
+
+    async def test_creates_episodes_for_matching_series(self, sync, db, make_library_item):
+        _make_svc(db, ServiceType.SONARR)
+        make_library_item(title="Breaking Bad", year=2008, media_type=MediaType.TV)
+        mock = _mock_sonarr_connector()
+        mock.get_episodes_by_series = AsyncMock(return_value=[_SONARR_EPISODE])
+        mock.get_episode_files_by_series = AsyncMock(return_value=[_SONARR_EPISODE_FILE])
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr_episodes()
+        assert result["success"] is True
+        assert result["episodes_synced"] == 1
+        ep = db.query(Episode).filter_by(sonarr_episode_id=101).first()
+        assert ep is not None
+        assert ep.title == "Pilot"
+        assert ep.has_file is True
+        assert ep.quality_profile == "Bluray-1080p"
+
+    async def test_updates_existing_episode(self, sync, db, make_library_item):
+        _make_svc(db, ServiceType.SONARR)
+        item = make_library_item(title="Breaking Bad", year=2008, media_type=MediaType.TV)
+        season = Season(library_item_id=item.id, sonarr_series_id=10, season_number=1)
+        db.add(season)
+        db.flush()
+        existing_ep = Episode(
+            season_id=season.id,
+            library_item_id=item.id,
+            sonarr_episode_id=101,
+            sonarr_series_id=10,
+            season_number=1,
+            episode_number=1,
+            title="Old Title",
+            monitored=True,
+            has_file=False,
+            downloaded=False,
+        )
+        db.add(existing_ep)
+        db.commit()
+        mock = _mock_sonarr_connector()
+        mock.get_episodes_by_series = AsyncMock(return_value=[_SONARR_EPISODE])
+        mock.get_episode_files_by_series = AsyncMock(return_value=[_SONARR_EPISODE_FILE])
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr_episodes()
+        assert result["episodes_updated"] == 1
+        db.refresh(existing_ep)
+        assert existing_ep.title == "Pilot"
+        assert existing_ep.has_file is True
+
+    async def test_skips_episode_missing_season_or_number(self, sync, db, make_library_item):
+        _make_svc(db, ServiceType.SONARR)
+        make_library_item(title="Breaking Bad", year=2008, media_type=MediaType.TV)
+        bad_episode = {**_SONARR_EPISODE, "seasonNumber": None}
+        mock = _mock_sonarr_connector()
+        mock.get_episodes_by_series = AsyncMock(return_value=[bad_episode])
+        mock.get_episode_files_by_series = AsyncMock(return_value=[])
+        with patch("app.schedulers.sync_service.SonarrConnector", return_value=mock):
+            result = await sync.sync_sonarr_episodes()
+        assert result["episodes_synced"] == 0
+
+
+# ── sync_monitored_items ──────────────────────────────────────────────────────
+
+
+class TestSyncMonitoredItems:
+    def _radarr_mock(self):
+        m = AsyncMock()
+        m.get_statistics = AsyncMock(
+            return_value={"monitored_movies": 10, "total_movies": 12, "downloaded_movies": 8, "missing_movies": 2}
+        )
+        m.close = AsyncMock()
+        return m
+
+    def _sonarr_mock(self):
+        m = AsyncMock()
+        m.get_statistics = AsyncMock(
+            return_value={"monitored_series": 5, "total_series": 7, "downloaded_episodes": 50, "missing_episodes": 5}
+        )
+        m.close = AsyncMock()
+        return m
+
+    async def test_aggregates_radarr_and_sonarr_stats(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        _make_svc(db, ServiceType.SONARR)
+        with (
+            patch("app.schedulers.sync_service.RadarrConnector", return_value=self._radarr_mock()),
+            patch("app.schedulers.sync_service.SonarrConnector", return_value=self._sonarr_mock()),
+        ):
+            result = await sync.sync_monitored_items()
+        assert result["success"] is True
+        assert result["monitored"] == 15  # 10 + 5
+
+    async def test_creates_dashboard_statistic(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        _make_svc(db, ServiceType.SONARR)
+        with (
+            patch("app.schedulers.sync_service.RadarrConnector", return_value=self._radarr_mock()),
+            patch("app.schedulers.sync_service.SonarrConnector", return_value=self._sonarr_mock()),
+        ):
+            await sync.sync_monitored_items()
+        stat = db.query(DashboardStatistic).filter_by(stat_type=StatType.MONITORED_ITEMS).first()
+        assert stat is not None
+        assert stat.total_count == 15
+        assert stat.details["downloaded"] == 58  # 8 + 50
+
+    async def test_works_when_only_radarr_configured(self, sync, db):
+        _make_svc(db, ServiceType.RADARR)
+        with patch("app.schedulers.sync_service.RadarrConnector", return_value=self._radarr_mock()):
+            result = await sync.sync_monitored_items()
+        assert result["success"] is True
+        assert result["monitored"] == 10
+
+    async def test_works_when_no_services_configured(self, sync, db):
+        result = await sync.sync_monitored_items()
+        assert result["success"] is True
+        assert result["monitored"] == 0
+
+
+# ── sync_jellyfin ─────────────────────────────────────────────────────────────
+
+
+def _mock_jellyfin_connector():
+    m = AsyncMock()
+    m.get_users = AsyncMock(return_value=[{"Policy": {"IsDisabled": False}}, {"Policy": {"IsDisabled": True}}])
+    m.get_library_items = AsyncMock(return_value={"movies": 50, "tv": 20})
+    m.get_total_watch_time = AsyncMock(return_value={"total_hours": 200})
+    m.get_movies_details = AsyncMock(return_value={"total_movies": 50, "total_hours": 300})
+    m.get_tv_shows_details = AsyncMock(return_value={"total_series": 20, "total_episodes": 400, "total_hours": 600})
+    m.close = AsyncMock()
+    return m
+
+
+class TestSyncJellyfin:
+    async def test_no_service_returns_failure(self, sync):
+        result = await sync.sync_jellyfin()
+        assert result["success"] is False
+
+    async def test_creates_user_dashboard_stat(self, sync, db):
+        _make_svc(db, ServiceType.JELLYFIN)
+        with patch("app.schedulers.sync_service.JellyfinConnector", return_value=_mock_jellyfin_connector()):
+            result = await sync.sync_jellyfin()
+        assert result["success"] is True
+        assert result["users"] == 2
+        stat = db.query(DashboardStatistic).filter_by(stat_type=StatType.USERS).first()
+        assert stat.total_count == 2
+        assert stat.details["active_users"] == 1
+
+    async def test_creates_movie_dashboard_stat(self, sync, db):
+        _make_svc(db, ServiceType.JELLYFIN)
+        with patch("app.schedulers.sync_service.JellyfinConnector", return_value=_mock_jellyfin_connector()):
+            await sync.sync_jellyfin()
+        stat = db.query(DashboardStatistic).filter_by(stat_type=StatType.MOVIES).first()
+        assert stat.total_count == 50
+        assert stat.details["total_hours"] == 300
+
+    async def test_creates_tv_dashboard_stat(self, sync, db):
+        _make_svc(db, ServiceType.JELLYFIN)
+        with patch("app.schedulers.sync_service.JellyfinConnector", return_value=_mock_jellyfin_connector()):
+            await sync.sync_jellyfin()
+        stat = db.query(DashboardStatistic).filter_by(stat_type=StatType.TV_SHOWS).first()
+        assert stat.total_count == 20
+        assert stat.details["total_episodes"] == 400
+
+    async def test_writes_sync_metadata(self, sync, db):
+        _make_svc(db, ServiceType.JELLYFIN)
+        with patch("app.schedulers.sync_service.JellyfinConnector", return_value=_mock_jellyfin_connector()):
+            await sync.sync_jellyfin()
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.JELLYFIN).first()
+        assert meta.sync_status == SyncStatus.SUCCESS
+
+    async def test_error_returns_failure_and_marks_failed(self, sync, db):
+        _make_svc(db, ServiceType.JELLYFIN)
+        mock = _mock_jellyfin_connector()
+        mock.get_users = AsyncMock(side_effect=Exception("timeout"))
+        with patch("app.schedulers.sync_service.JellyfinConnector", return_value=mock):
+            result = await sync.sync_jellyfin()
+        assert result["success"] is False
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.JELLYFIN).first()
+        assert meta.sync_status == SyncStatus.FAILED
+
+
+# ── sync_jellyseerr ───────────────────────────────────────────────────────────
+
+_JS_REQUEST = {
+    "id": 1,
+    "type": "movie",
+    "status": 2,
+    "is4k": False,
+    "createdAt": "2024-01-10T12:00:00Z",
+    "media": {"tmdbId": 27205},
+    "requestedBy": {"displayName": "Alice", "avatar": "http://example.com/alice.jpg", "id": 10},
+}
+
+_JS_MEDIA_DETAILS = {
+    "title": "Inception",
+    "releaseDate": "2010-07-16",
+    "overview": "A mind-bending thriller.",
+    "posterPath": "/poster.jpg",
+}
+
+
+def _mock_jellyseerr_connector(requests=None, connection_ok=True):
+    m = AsyncMock()
+    m.test_connection = AsyncMock(return_value=(connection_ok, "OK"))
+    m.get_requests = AsyncMock(return_value=requests if requests is not None else [_JS_REQUEST])
+    m.get_media_details = AsyncMock(return_value=_JS_MEDIA_DETAILS)
+    m.close = AsyncMock()
+    return m
+
+
+class TestSyncJellyseerr:
+    async def test_no_service_returns_failure(self, sync):
+        result = await sync.sync_jellyseerr()
+        assert result["success"] is False
+
+    async def test_creates_new_request(self, sync, db):
+        _make_svc(db, ServiceType.JELLYSEERR)
+        with patch("app.schedulers.sync_service.JellyseerrConnector", return_value=_mock_jellyseerr_connector()):
+            result = await sync.sync_jellyseerr()
+        assert result["success"] is True
+        assert result["requests_added"] == 1
+        req = db.query(JellyseerrRequest).filter_by(jellyseerr_id=1).first()
+        assert req is not None
+        assert req.title == "Inception"
+        assert req.requested_by == "Alice"
+
+    async def test_updates_existing_request(self, sync, db):
+        _make_svc(db, ServiceType.JELLYSEERR)
+        from app.models import RequestPriority, RequestStatus
+
+        existing = JellyseerrRequest(
+            jellyseerr_id=1,
+            title="Old Title",
+            media_type=MediaType.MOVIE,
+            year=2010,
+            image_url="",
+            image_alt="",
+            status=RequestStatus.PENDING,
+            priority=RequestPriority.MEDIUM,
+            requested_by="Bob",
+            requested_date="Unknown",
+            quality="1080p",
+        )
+        db.add(existing)
+        db.commit()
+        with patch("app.schedulers.sync_service.JellyseerrConnector", return_value=_mock_jellyseerr_connector()):
+            result = await sync.sync_jellyseerr()
+        assert result["requests_updated"] == 1
+        db.refresh(existing)
+        assert existing.title == "Inception"
+        assert existing.requested_by == "Alice"
+
+    async def test_deletes_stale_requests(self, sync, db):
+        _make_svc(db, ServiceType.JELLYSEERR)
+        from app.models import RequestPriority, RequestStatus
+
+        stale = JellyseerrRequest(
+            jellyseerr_id=999,  # not in API response
+            title="Stale",
+            media_type=MediaType.MOVIE,
+            year=2000,
+            image_url="",
+            image_alt="",
+            status=RequestStatus.PENDING,
+            priority=RequestPriority.MEDIUM,
+            requested_by="Ghost",
+            requested_date="Unknown",
+            quality="1080p",
+        )
+        db.add(stale)
+        db.commit()
+        with patch("app.schedulers.sync_service.JellyseerrConnector", return_value=_mock_jellyseerr_connector()):
+            result = await sync.sync_jellyseerr()
+        assert result["requests_deleted"] == 1
+        assert db.query(JellyseerrRequest).filter_by(jellyseerr_id=999).first() is None
+
+    async def test_deletes_all_when_api_returns_empty(self, sync, db):
+        _make_svc(db, ServiceType.JELLYSEERR)
+        from app.models import RequestPriority, RequestStatus
+
+        for i in range(3):
+            db.add(
+                JellyseerrRequest(
+                    jellyseerr_id=i,
+                    title=f"Movie {i}",
+                    media_type=MediaType.MOVIE,
+                    year=2020,
+                    image_url="",
+                    image_alt="",
+                    status=RequestStatus.PENDING,
+                    priority=RequestPriority.MEDIUM,
+                    requested_by="User",
+                    requested_date="Unknown",
+                    quality="1080p",
+                )
+            )
+        db.commit()
+        mock = _mock_jellyseerr_connector(requests=[])
+        with patch("app.schedulers.sync_service.JellyseerrConnector", return_value=mock):
+            result = await sync.sync_jellyseerr()
+        assert result["requests_deleted"] == 3
+        assert db.query(JellyseerrRequest).count() == 0
+
+    async def test_connection_failure_returns_failure(self, sync, db):
+        _make_svc(db, ServiceType.JELLYSEERR)
+        mock = _mock_jellyseerr_connector(connection_ok=False)
+        mock.test_connection = AsyncMock(return_value=(False, "refused"))
+        with patch("app.schedulers.sync_service.JellyseerrConnector", return_value=mock):
+            result = await sync.sync_jellyseerr()
+        assert result["success"] is False
+        meta = db.query(SyncMetadata).filter_by(service_name=ServiceType.JELLYSEERR).first()
+        assert meta.sync_status == SyncStatus.FAILED


### PR DESCRIPTION
## Summary

- Add 151 tests across 4 new test files covering previously untested backend code
- Remove 5 unused API endpoints identified by frontend audit

## Tests added

- **`test_prowlarr_connector.py`** (30 tests) — full unit coverage of `ProwlarrConnector`: indexers, stats merging, history mapping, search, grab, toggle
- **`test_prowlarr_routes.py`** (25 tests) — route integration tests for all `/api/prowlarr` endpoints incl. 503/502/422 error cases
- **`test_radarr_connector.py`** (37 tests) — full unit coverage of `RadarrConnector`: `_extract_hash`, recent additions filtering, statistics, quality profiles
- **`test_sync_service.py`** (59 tests) — full coverage of `SyncService`: all sync methods (radarr, sonarr, sonarr_seasons, sonarr_episodes, jellyfin, jellyseerr, monitored_items), upsert helpers, `_format_time_ago`

## Endpoints removed

Confirmed unused by frontend audit — functionality covered by other means:

- `GET /api/dashboard/` — frontend uses individual sub-routes
- `POST /api/torrents/enrich` — enrichment already runs via scheduler and `/api/sync/trigger`
- `POST /api/torrents/enrich/recent` — same reason
- `GET /api/services/` — frontend fetches services individually by name
- `POST /api/services/` — frontend uses `PUT` upsert instead

## Test plan

- [x] All 389 backend tests pass
- [x] Ruff lint + format clean
- [x] No frontend calls to removed endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)